### PR TITLE
Removing bubble when clicking outside of Editor

### DIFF
--- a/src/js/jquery.notebook.js
+++ b/src/js/jquery.notebook.js
@@ -612,8 +612,7 @@
                 actions.setPlaceholder.call(this, {
                     focus: false
                 });
-                var elem = this;
-                bubble.clear.call(elem);
+                bubble.clear.call(this);
             }
         },
         events = {

--- a/src/js/jquery.notebook.js
+++ b/src/js/jquery.notebook.js
@@ -612,6 +612,8 @@
                 actions.setPlaceholder.call(this, {
                     focus: false
                 });
+                var elem = this;
+                bubble.clear.call(elem);
             }
         },
         events = {


### PR DESCRIPTION
This commit resolved the issue that keeps the bubble popup opened when user clicks outside of the editor window.
